### PR TITLE
Add support for ETH Goerli testnet

### DIFF
--- a/authgear-nft-indexer.yaml.example
+++ b/authgear-nft-indexer.yaml.example
@@ -15,9 +15,9 @@ worker:
 server:
   listen_addr: 0.0.0.0:8080
 alchemy:
-  api_key:
-    - name: eth_mainnet
-      value: 
-    - name: eth_goerli
-      value: 
-
+  - blockchain: ethereum
+    network: "1"
+    api_key: 
+  - blockchain: ethereum
+    network: "5"
+    api_key: 

--- a/authgear-nft-indexer.yaml.example
+++ b/authgear-nft-indexer.yaml.example
@@ -16,3 +16,8 @@ server:
   listen_addr: 0.0.0.0:8080
 alchemy:
   api_key:
+    - name: eth_mainnet
+      value: 
+    - name: eth_goerli
+      value: 
+

--- a/pkg/api/model/server.go
+++ b/pkg/api/model/server.go
@@ -6,14 +6,15 @@ import (
 )
 
 type NFTCollection struct {
-	ID              string  `json:"id"`
-	Blockchain      string  `json:"blockchain"`
-	Network         string  `json:"network"`
-	Name            string  `json:"name"`
-	BlockHeight     big.Int `json:"block_height"`
-	ContractAddress string  `json:"contract_address"`
-	TotalSupply     big.Int `json:"total_supply"`
-	Type            string  `json:"type"`
+	ID              string    `json:"id"`
+	Blockchain      string    `json:"blockchain"`
+	Network         string    `json:"network"`
+	Name            string    `json:"name"`
+	BlockHeight     big.Int   `json:"block_height"`
+	ContractAddress string    `json:"contract_address"`
+	TotalSupply     big.Int   `json:"total_supply"`
+	Type            string    `json:"type"`
+	CreatedAt       time.Time `json:"created_at"`
 }
 
 type WatchCollectionRequestData struct {

--- a/pkg/config/alchemy.go
+++ b/pkg/config/alchemy.go
@@ -1,16 +1,65 @@
 package config
 
+var _ = Schema.Add("NetworkName", `
+{
+	"type": "string",
+	"enum": ["eth_mainnet", "eth_goerli"]
+}
+`)
+
+type NetworkName string
+
+const (
+	NetworkNameEthereumMainnet NetworkName = "eth_mainnet"
+	NetworkNameEthereumGoerli  NetworkName = "eth_goerli"
+)
+
+var _ = Schema.Add("APIKeyConfig", `
+{
+	"type": "object",
+	"additionalProperties": false,
+	"properties": {
+		"name": { "$ref": "#/$defs/NetworkName" },
+		"value": { "type": "string" }
+	},
+	"required": ["name", "value"]
+}
+`)
+
+type APIKeyConfig struct {
+	NetworkName NetworkName `json:"name"`
+	APIKey      string      `json:"value"`
+}
+
 var _ = Schema.Add("AlchemyConfig", `
 {
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {
-		"api_key": { "type": "string" }
+		"api_key": { "type": "array", "items": { "$ref":"#/$defs/APIKeyConfig" } }
 	},
 	"required": ["api_key"]
 }
 `)
 
 type AlchemyConfig struct {
-	APIKey string `json:"api_key"`
+	APIKeys []APIKeyConfig `json:"api_key"`
+}
+
+func (a *AlchemyConfig) getAPIKeyByNetworkName(name NetworkName) string {
+	for _, keyConfig := range a.APIKeys {
+		if keyConfig.NetworkName == name {
+			return keyConfig.APIKey
+		}
+	}
+
+	return ""
+}
+
+func (a *AlchemyConfig) GetETHMainnetAPIKey() string {
+	return a.getAPIKeyByNetworkName(NetworkNameEthereumMainnet)
+}
+
+func (a *AlchemyConfig) GetETHGoerliAPIKey() string {
+	return a.getAPIKeyByNetworkName(NetworkNameEthereumGoerli)
 }

--- a/pkg/config/alchemy.go
+++ b/pkg/config/alchemy.go
@@ -1,65 +1,20 @@
 package config
 
-var _ = Schema.Add("NetworkName", `
-{
-	"type": "string",
-	"enum": ["eth_mainnet", "eth_goerli"]
-}
-`)
-
-type NetworkName string
-
-const (
-	NetworkNameEthereumMainnet NetworkName = "eth_mainnet"
-	NetworkNameEthereumGoerli  NetworkName = "eth_goerli"
-)
-
-var _ = Schema.Add("APIKeyConfig", `
-{
-	"type": "object",
-	"additionalProperties": false,
-	"properties": {
-		"name": { "$ref": "#/$defs/NetworkName" },
-		"value": { "type": "string" }
-	},
-	"required": ["name", "value"]
-}
-`)
-
-type APIKeyConfig struct {
-	NetworkName NetworkName `json:"name"`
-	APIKey      string      `json:"value"`
-}
-
 var _ = Schema.Add("AlchemyConfig", `
 {
 	"type": "object",
 	"additionalProperties": false,
 	"properties": {
-		"api_key": { "type": "array", "items": { "$ref":"#/$defs/APIKeyConfig" } }
+		"blockchain": { "type": "string" },
+		"network": { "type": "string" },
+		"api_key": { "type": "string" }
 	},
-	"required": ["api_key"]
+	"required": ["blockchain", "network", "api_key"]
 }
 `)
 
 type AlchemyConfig struct {
-	APIKeys []APIKeyConfig `json:"api_key"`
-}
-
-func (a *AlchemyConfig) getAPIKeyByNetworkName(name NetworkName) string {
-	for _, keyConfig := range a.APIKeys {
-		if keyConfig.NetworkName == name {
-			return keyConfig.APIKey
-		}
-	}
-
-	return ""
-}
-
-func (a *AlchemyConfig) GetETHMainnetAPIKey() string {
-	return a.getAPIKeyByNetworkName(NetworkNameEthereumMainnet)
-}
-
-func (a *AlchemyConfig) GetETHGoerliAPIKey() string {
-	return a.getAPIKeyByNetworkName(NetworkNameEthereumGoerli)
+	Blockchain string `json:"blockchain"`
+	Network    string `json:"network"`
+	APIKey     string `json:"api_key"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,18 +18,18 @@ var _ = Schema.Add("Config", `
 		"worker": { "$ref": "#/$defs/WorkerConfig" },
 		"database": { "$ref": "#/$defs/DatabaseConfig" },
 		"server": { "$ref": "#/$defs/ServerConfig" },
-		"alchemy": { "$ref": "#/$defs/AlchemyConfig" }
+		"alchemy": { "type": "array", "items": { "$ref": "#/$defs/AlchemyConfig" } }
 	},
 	"required": ["redis", "worker", "database", "server", "alchemy"]
 }
 `)
 
 type Config struct {
-	Redis    RedisConfig    `json:"redis"`
-	Worker   WorkerConfig   `json:"worker"`
-	Database DatabaseConfig `json:"database"`
-	Server   ServerConfig   `json:"server"`
-	Alchemy  AlchemyConfig  `json:"alchemy"`
+	Redis    RedisConfig     `json:"redis"`
+	Worker   WorkerConfig    `json:"worker"`
+	Database DatabaseConfig  `json:"database"`
+	Server   ServerConfig    `json:"server"`
+	Alchemy  []AlchemyConfig `json:"alchemy"`
 }
 
 func Parse(inputYAML []byte) (*Config, error) {

--- a/pkg/handler/get_collection.go
+++ b/pkg/handler/get_collection.go
@@ -69,6 +69,7 @@ func (h *GetCollectionAPIHandler) ServeHTTP(resp http.ResponseWriter, req *http.
 			BlockHeight:     *collection.FromBlockHeight.ToMathBig(),
 			TotalSupply:     *collection.TotalSupply.ToMathBig(),
 			Type:            string(collection.Type),
+			CreatedAt:       collection.CreatedAt,
 		},
 	})
 }

--- a/pkg/handler/list_collection.go
+++ b/pkg/handler/list_collection.go
@@ -67,6 +67,7 @@ func (h *ListCollectionAPIHandler) ServeHTTP(resp http.ResponseWriter, req *http
 			ContractAddress: collection.ContractAddress,
 			TotalSupply:     *collection.TotalSupply.ToMathBig(),
 			Type:            string(collection.Type),
+			CreatedAt:       collection.CreatedAt,
 		})
 	}
 

--- a/pkg/handler/watch_collection.go
+++ b/pkg/handler/watch_collection.go
@@ -122,6 +122,7 @@ func (h *WatchCollectionAPIHandler) ServeHTTP(resp http.ResponseWriter, req *htt
 			Network:         collection.Network,
 			Name:            collection.Name,
 			ContractAddress: collection.ContractAddress,
+			CreatedAt:       collection.CreatedAt,
 			BlockHeight:     *collection.FromBlockHeight.ToMathBig(),
 			Type:            string(collection.Type),
 			TotalSupply:     *collection.TotalSupply.ToMathBig(),

--- a/pkg/web3/alchemy.go
+++ b/pkg/web3/alchemy.go
@@ -19,7 +19,7 @@ type AlchemyAPI struct {
 }
 
 func (a *AlchemyAPI) GetNFTTransfers(blockchain string, network string, contractAddresses []string, fromBlock string, toBlock string, pageKey string, maxCount int64) (*apimodel.AssetTransferResponse, error) {
-	alchemyEndpoints, err := GetRequestEndpoints(blockchain, network)
+	alchemyEndpoints, err := GetRequestEndpoints(a.Config.Alchemy, blockchain, network)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +52,6 @@ func (a *AlchemyAPI) GetNFTTransfers(blockchain string, network string, contract
 	}
 
 	requestURL := alchemyEndpoints.TransferEndpoint
-	requestURL.Path = path.Join(requestURL.Path, a.Config.Alchemy.APIKey)
 
 	log.Printf("Requesting NFT Transfers for contractAddresses: %s from network %s %s, fromBlock %s, toBlock %s", strings.Join(contractAddresses, ", "), blockchain, network, fromBlock, toBlock)
 	res, err := http.Post(requestURL.String(), "application/json", bytes.NewBuffer(jsonBody))
@@ -75,7 +74,7 @@ func (a *AlchemyAPI) GetNFTTransfers(blockchain string, network string, contract
 }
 
 func (a *AlchemyAPI) GetContractMetadata(blockchain string, network string, contractAddress string) (*apimodel.ContractMetadataResponse, error) {
-	alchemyEndpoints, err := GetRequestEndpoints(blockchain, network)
+	alchemyEndpoints, err := GetRequestEndpoints(a.Config.Alchemy, blockchain, network)
 
 	if err != nil {
 		return nil, err
@@ -86,7 +85,7 @@ func (a *AlchemyAPI) GetContractMetadata(blockchain string, network string, cont
 	}
 
 	requestURL := alchemyEndpoints.TransferEndpoint
-	requestURL.Path = path.Join(requestURL.Path, a.Config.Alchemy.APIKey, "getContractMetadata")
+	requestURL.Path = path.Join(requestURL.Path, "getContractMetadata")
 
 	requestQuery := requestURL.Query()
 	requestQuery.Set("contractAddress", contractAddress)

--- a/pkg/web3/endpoints.go
+++ b/pkg/web3/endpoints.go
@@ -18,7 +18,7 @@ type AlchemyEndpoint struct {
 	NFTEndpoint      *url.URL
 }
 
-func GetAlchemyEndpoint(alchemyConfig config.AlchemyConfig, blockchain string, network string) (endpoint string, apiKey string) {
+func GetAlchemyEndpoint(blockchain string, network string) string {
 	switch blockchain {
 	case "ethereum":
 		chainID, err := strconv.Atoi(network)
@@ -28,9 +28,9 @@ func GetAlchemyEndpoint(alchemyConfig config.AlchemyConfig, blockchain string, n
 
 		switch chainID {
 		case 1:
-			return EthereumMainnetAlchemyEndpoint, alchemyConfig.GetETHMainnetAPIKey()
+			return EthereumMainnetAlchemyEndpoint
 		case 5:
-			return EthereumGoerliAlchemyEndpoint, alchemyConfig.GetETHGoerliAPIKey()
+			return EthereumGoerliAlchemyEndpoint
 		default:
 			panic("unsupported chain ID")
 		}
@@ -39,8 +39,16 @@ func GetAlchemyEndpoint(alchemyConfig config.AlchemyConfig, blockchain string, n
 	panic("unsupported blockchain")
 }
 
-func GetRequestEndpoints(config config.AlchemyConfig, blockchain string, network string) (*AlchemyEndpoint, error) {
-	endpoint, apiKey := GetAlchemyEndpoint(config, blockchain, network)
+func GetRequestEndpoints(alchemyConfigs []config.AlchemyConfig, blockchain string, network string) (*AlchemyEndpoint, error) {
+	endpoint := GetAlchemyEndpoint(blockchain, network)
+
+	apiKey := ""
+	for _, alchemyConfig := range alchemyConfigs {
+		if alchemyConfig.Blockchain == blockchain && alchemyConfig.Network == network {
+			apiKey = alchemyConfig.APIKey
+			break
+		}
+	}
 
 	url, err := url.Parse(endpoint)
 	if err != nil {


### PR DESCRIPTION
According to AlchemyAPI, Ropsten and Kovan network are deprecated and they will end support for Rinkeby soon, in which all of them will be removed at  the start of Oct, so we are only supporting Goerli for now